### PR TITLE
Add client pooling, timeouts and retries

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -20,7 +20,7 @@
 import logging
 import structlog
 
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.ERROR)
 
 structlog.configure(
     logger_factory=structlog.stdlib.LoggerFactory(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,12 +28,11 @@ from pathlib import PurePath
 
 import pytest
 
+from partisan.icommands import have_admin, imkdir, iput, irm, mkgroup, rmgroup
 from partisan.irods import (
     AVU,
-    Baton,
     Collection,
 )
-from partisan.icommands import have_admin, imkdir, iput, irm, mkgroup, rmgroup
 from partisan.metadata import ONTMetadata
 
 tests_have_admin = pytest.mark.skipif(
@@ -160,14 +159,3 @@ def ont_synthetic(tmp_path, baton_session):
     finally:
         irm(root_path, force=True, recurse=True)
         remove_test_groups()
-
-
-@pytest.fixture(scope="function")
-def baton_session():
-    client = Baton()
-    client.start()
-
-    try:
-        yield client
-    finally:
-        client.stop()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -17,11 +17,9 @@
 #
 # @author Keith James <kdj@sanger.ac.uk>
 
-import pytest
 from pytest import mark as m
 
-from partisan.exception import RodsError
-from partisan.irods import Baton, Collection, DataObject
+from partisan.irods import Baton
 
 
 @m.describe("Baton")
@@ -29,55 +27,28 @@ class TestBatonClient(object):
     @m.context("When created")
     @m.it("Is not running")
     def test_create_baton_client(self):
-        client = Baton()
-        assert not client.is_running()
+        c = Baton()
+        assert not c.is_running()
 
     @m.it("Can be started and stopped")
     def test_start_baton_client(self):
-        client = Baton()
-        client.start()
-        assert client.is_running()
-        client.stop()
-        assert not client.is_running()
+        c = Baton()
+        c.start()
+        assert c.is_running()
+        c.stop()
+        assert not c.is_running()
 
     @m.context("When stopped")
     @m.it("Can be re-started")
     def test_restart_baton_client(self, simple_collection):
-        client = Baton()
-        client.start()
-        assert client.is_running()
-        client.stop()
-        assert not client.is_running()
-        # Re-start
-        client.start()
-        assert client.is_running()
-        # Try an operation
-        coll = Collection(client, simple_collection)
-        assert coll.exists()
-        client.stop()
-
-    @m.contect("When used as a ContextManager")
-    @m.it("Starts on context entry")
-    def test_context_enter(self):
-        with Baton() as client:
-            assert client.is_running()
-
-    @m.it("Stops on context exit")
-    def test_context_exit(self):
-        c: Baton
-        with Baton() as client:
-            c = client
-
+        c = Baton()
+        c.start()
+        assert c.is_running()
+        c.stop()
         assert not c.is_running()
 
-    @m.it("Stops on a raised exception")
-    def test_context_exit(self):
-        c: Baton
-        with Baton() as client:
-            c = client
-            obj = DataObject(client, "/no/such/path")
-
-            with pytest.raises(RodsError, match=r"does not exist"):
-                obj.list()
-
+        # Re-start
+        c.start()
+        assert c.is_running()
+        c.stop()
         assert not c.is_running()

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright © 2021 Genome Research Ltd. All rights reserved.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# @author Keith James <kdj@sanger.ac.uk>
+
+from queue import Empty
+
+import pytest
+from pytest import mark as m
+
+from partisan.irods import client, client_pool
+
+
+@m.describe("BatonPool")
+class TestBatonPool(object):
+    @m.context("When created")
+    @m.it("Is open")
+    def test_pool_is_open(self):
+        with client_pool() as p:
+            assert p.is_open()
+
+    @m.context("When the pool is open")
+    @m.it("Yields up to maxsize running clients")
+    def test_get_clients(self):
+        with client_pool(maxsize=2) as p:
+            with client(p) as c1:
+                assert c1.is_running()
+                with client(p) as c2:
+                    assert c2.is_running()
+
+    @m.context("After getting maxsize clients")
+    @m.it("Getting another client times out")
+    def test_get_clients(self):
+        with client_pool(maxsize=1) as p:
+            with client(p) as c1:
+                assert c1.is_running()
+                with pytest.raises(Empty):
+                    with client(p, timeout=1) as _:
+                        pass
+
+    @m.context("When the pool is closed")
+    @m.it("Stops its clients")
+    def test_pool_close(self):
+        pool_size = 2
+        clients = list()
+        with client_pool(maxsize=pool_size) as p:
+            for _ in range(pool_size):
+                with client(p) as c:
+                    clients.append(c)
+                    assert c.is_running()
+
+        assert len(clients) == pool_size
+        for c in clients:
+            assert not c.is_running()


### PR DESCRIPTION
This is a breaking change to the API which simplifies things for the
API consumer and adds features to help when iRODS operations time out
because of network or server issues.

The constructors of Collection and DataObject no longer take a Baton
client as their first argument. Instead, Collection and DataObject
reference a pool of clients which they draw on to perform
operations. This means that if a client encounters problems, it can be
returned to the pool to be restarted. If no pool is specified on
construction, a default, threadsafe pool of 4 clients is used, shared
between all Collection and DataObjects.

All remote operations now support a timeout and a number of
tries. These default to no timeout and 1 try, to retain the original
behaviour.